### PR TITLE
Add github repo link to how-to/write-documentation.

### DIFF
--- a/doc/de/how-to/write-documentation.markdown
+++ b/doc/de/how-to/write-documentation.markdown
@@ -7,8 +7,9 @@ next: Dokumentation übersetzen
 next_url: how-to/translate-documentation
 ---
 
-Die Dokumentation für Rubinius ist integriert mit der Website und dem Blog. Sie
-nutzt genau wie die übrigen Komponenten Jekyll.
+Die Dokumentation für Rubinius ist integriert mit der Website und dem Blog
+[github.com/rubinius/rubinius.github.io](https://github.com/rubinius/rubinius.github.io).
+Sie nutzt genau wie die übrigen Komponenten Jekyll.
 
 Um zu starten, stelle sicher, dass du die `kramdown` und `jekyll` Gems 
 installiert hast.

--- a/doc/en/how-to/write-documentation.markdown
+++ b/doc/en/how-to/write-documentation.markdown
@@ -7,8 +7,9 @@ next: Translate Documentation
 next_url: how-to/translate-documentation
 ---
 
-The Rubinius documentation is integrated with the website and blog. It uses
-Jekyll just like the other components.
+The Rubinius documentation is integrated with the website and blog at
+[github.com/rubinius/rubinius.github.io](https://github.com/rubinius/rubinius.github.io).
+It uses Jekyll just like the other components.
 
 To get started, use `bundler` inside your local repository clone:
 

--- a/doc/es/how-to/write-documentation.markdown
+++ b/doc/es/how-to/write-documentation.markdown
@@ -7,7 +7,8 @@ next: Traducir documentación
 next_url: how-to/translate-documentation
 ---
 
-La documentación de Rubinius está integrada con el sitio web y el blog.
+La documentación de Rubinius está integrada con el sitio web y el blog
+[github.com/rubinius/rubinius.github.io](https://github.com/rubinius/rubinius.github.io).
 Utiliza Jekyll al igual que los otros componentes.
 
 Para empezar, asegúrate de tener las gemas `kramdown` y `jekyll` instaladas.

--- a/doc/fr/how-to/write-documentation.markdown
+++ b/doc/fr/how-to/write-documentation.markdown
@@ -7,8 +7,9 @@ next: Translate Documentation
 next_url: how-to/translate-documentation
 ---
 
-The Rubinius documentation is integrated with the website and blog. It uses
-Jekyll just like the other components.
+The Rubinius documentation is integrated with the website and blog at
+[github.com/rubinius/rubinius.github.io](https://github.com/rubinius/rubinius.github.io).
+It uses Jekyll just like the other components.
 
 To get started, ensure you have the `kramdown` and `jekyll` gems installed.
 

--- a/doc/it/how-to/write-documentation.markdown
+++ b/doc/it/how-to/write-documentation.markdown
@@ -7,8 +7,9 @@ next: Translate Documentation
 next_url: how-to/translate-documentation
 ---
 
-The Rubinius documentation is integrated with the website and blog. It uses
-Jekyll just like the other components.
+The Rubinius documentation is integrated with the website and blog at
+[github.com/rubinius/rubinius.github.io](https://github.com/rubinius/rubinius.github.io).
+It uses Jekyll just like the other components.
 
 To get started, ensure you have the `kramdown` and `jekyll` gems installed.
 

--- a/doc/ja/how-to/write-documentation.markdown
+++ b/doc/ja/how-to/write-documentation.markdown
@@ -8,7 +8,9 @@ next_url: how-to/translate-documentation
 translated: true
 ---
 
-Rubiniusのドキュメントは、Webサイトとブログで構成されています。他の部分と同じくJekyllを使用しています。
+Rubiniusのドキュメントは、Webサイトとブログで構成されています。
+[github.com/rubinius/rubinius.github.io](https://github.com/rubinius/rubinius.github.io)
+他の部分と同じくJekyllを使用しています。
 
 始めに、`kramdown`と`jekyll`がインストールされていることを確かめてください。
 

--- a/doc/pl/how-to/write-documentation.markdown
+++ b/doc/pl/how-to/write-documentation.markdown
@@ -7,8 +7,9 @@ next: Jak przetłumaczyć dokumentację
 next_url: how-to/translate-documentation
 ---
 
-The Rubinius documentation is integrated with the website and blog. It uses
-Jekyll just like the other components.
+The Rubinius documentation is integrated with the website and blog at
+[github.com/rubinius/rubinius.github.io](https://github.com/rubinius/rubinius.github.io).
+It uses Jekyll just like the other components.
 
 To get started, ensure you have the `kramdown` and `jekyll` gems installed.
 

--- a/doc/pt-br/how-to/write-documentation.markdown
+++ b/doc/pt-br/how-to/write-documentation.markdown
@@ -7,8 +7,9 @@ next: Translate Documentation
 next_url: how-to/translate-documentation
 ---
 
-The Rubinius documentation is integrated with the website and blog. It uses
-Jekyll just like the other components.
+The Rubinius documentation is integrated with the website and blog at
+[github.com/rubinius/rubinius.github.io](https://github.com/rubinius/rubinius.github.io).
+It uses Jekyll just like the other components.
 
 To get started, ensure you have the `kramdown` and `jekyll` gems installed.
 

--- a/doc/ru/how-to/write-documentation.markdown
+++ b/doc/ru/how-to/write-documentation.markdown
@@ -7,8 +7,9 @@ next: Перевод документации
 next_url: how-to/translate-documentation
 ---
 
-Документация по Rubinius интегрирована с веб-сайтом и блогом. Для нее также
-как и для других компонентов используется Jekyll.
+Документация по Rubinius интегрирована с веб-сайтом и блогом
+[github.com/rubinius/rubinius.github.io](https://github.com/rubinius/rubinius.github.io).
+Для нее также как и для других компонентов используется Jekyll.
 
 Для начала убедитесь, что у вас установлены гемы `kramdown` и `jekyll`.
 


### PR DESCRIPTION
I was a little confused where to find the repo
with the documentation at first. I hope this
change makes contributing documentation changes
easier for others in the future.