### PR TITLE
Change wording about adding Rubinius to PATH

### DIFF
--- a/doc/en/getting-started/building.markdown
+++ b/doc/en/getting-started/building.markdown
@@ -8,7 +8,7 @@ next_url: getting-started/running-rubinius
 ---
 
 You can build and run Rubinius from the source directory. You do not need to
-install Rubinius to run it. The directions below will detail both installing
+install Rubinius to run it. The directions below describe both installing
 Rubinius and running it from the source directory.
 
 Rubinius uses LLVM for the JIT compiler and depends on LLVM 3.x. The
@@ -41,7 +41,7 @@ superuser privileges. To install Rubinius:
   1. `bundle install`
   2. `./configure --prefix=/path/to/install/dir`
   3. `rake install`
-  4. Follow the directions to add the Rubinius _bin_ directory to your PATH
+  4. Add the Rubinius _bin_ directory to your PATH
 
 
 ### Running from the Source Directory
@@ -51,8 +51,7 @@ If you plan to work on Rubinius itself, you should use this option.
   1. `./configure`
   2. `rake`
 
-If you are just trying out Rubinius, follow the directions to add the _bin_
-directory to your PATH.
+If you are just trying out Rubinius, add the _bin_ directory to your PATH.
 
 However, if you are developing Rubinius, you should NOT add the _bin_
 directory to your PATH because the Rubinius build system will pick up the


### PR DESCRIPTION
There are no directions on the same page about adding stuff to PATH and no reference to another page where these directions are found, so it seems more straightforward to tell people to just do it.