### PR TITLE
Correct package name for Fedora

### DIFF
--- a/doc/en/getting-started/requirements.markdown
+++ b/doc/en/getting-started/requirements.markdown
@@ -55,7 +55,7 @@ should also install the `libedit-dev` package.
   * zlib-devel
   * openssl-devel
   * libedit-devel
-  * llvm-static
+  * llvm-static (llvm35-static for Fedora 23 and higher)
 
 ### FreeBSD
 


### PR DESCRIPTION
by default `llvm-static` packages on Fedora points to the latest one, but Rubinius needs the version <3 and >3.5